### PR TITLE
Convert comments to docstrings

### DIFF
--- a/main.py
+++ b/main.py
@@ -5,23 +5,29 @@ import requests
 import time
 import pkg_resources
 
-#load icd 9 to icd 10 mapping file
-#https://www.cms.gov/Medicare/Coding/ICD10/2018-ICD-10-CM-and-GEMs.html
 def load_icd9to10():
+    """
+    load icd 9 to icd 10 mapping file
+    https://www.cms.gov/Medicare/Coding/ICD10/2018-ICD-10-CM-and-GEMs.html
+    """
     icd9to10 = pd.read_csv(pkg_resources.resource_filename(__name__,'2018_I9gem.txt'),delim_whitespace=True,header=None,dtype=str)
     icd9to10.columns=['icd9','icd10','flag']
     return icd9to10
 
-#load icd 10 to icd 9 mapping file
-#https://www.cms.gov/Medicare/Coding/ICD10/2018-ICD-10-CM-and-GEMs.html
 def load_icd10to9():
+    """
+    load icd 10 to icd 9 mapping file
+    https://www.cms.gov/Medicare/Coding/ICD10/2018-ICD-10-CM-and-GEMs.html
+    """
     icd10to9 = pd.read_csv(pkg_resources.resource_filename(__name__,'2018_I10gem.txt'),delim_whitespace=True,header=None,dtype=str)
     icd10to9.columns=['icd10','icd9','flag']
     return icd10to9
 
-#convert icd 9 to 10, or 10 to 9
-#https://www.cms.gov/Medicare/Coding/ICD10/2018-ICD-10-CM-and-GEMs.html
 def icdconvert(df,col_icd='icd',icd_version=9):
+    """
+    convert icd 9 to 10, or 10 to 9
+    https://www.cms.gov/Medicare/Coding/ICD10/2018-ICD-10-CM-and-GEMs.html
+    """
     if icd_version==9:
         source='icd9'
         target='icd10'
@@ -45,16 +51,18 @@ def icdconvert(df,col_icd='icd',icd_version=9):
     
     return output
 
-# load Elixhauser comorbidities mapping file
-#Quan H, Sundararajan V, Halfon P, Fong A, Burnand B, Luthi JC, Saunders LD, Beck CA, Feasby TE, Ghali WA. 
-#Coding algorithms for defining comorbidities in ICD-9-CM and ICD-10 administrative data. 
-#Medical care. 2005 Nov 1:1130-9.
 def loadelixcomo():
+    """
+    load Elixhauser comorbidities mapping file
+    Quan H, Sundararajan V, Halfon P, Fong A, Burnand B, Luthi JC, Saunders LD, Beck CA, Feasby TE, Ghali WA. 
+    Coding algorithms for defining comorbidities in ICD-9-CM and ICD-10 administrative data. 
+    Medical care. 2005 Nov 1:1130-9.
+    """
     elixcomo = pd.read_csv(pkg_resources.resource_filename(__name__,'Elixhauser_Comorbidities.csv')).iloc[:,1:]
     return elixcomo
 
-#convert icd 9 or 10 to Elixhauser Comorbidities
 def icdtoelixcomo(df,col_icd):
+    """convert icd 9 or 10 to Elixhauser Comorbidities"""
     elixcomo = loadelixcomo()
     unqcomos = elixcomo['Comorbidity'].unique()
     df['ElixComo']=None
@@ -67,11 +75,13 @@ def icdtoelixcomo(df,col_icd):
     return df
   
 
-# score patients based on elixhauser comorbidities
-#van Walraven C, Austin PC, Jennings A, Quan H, Forster AJ. 
-#A modification of the Elixhauser comorbidity measures into a point system for hospital death using administrative data. 
-#Medical care. 2009 Jun 1:626-33.
 def elixcomoscore(df,col_icd,col_id):
+    """
+    score patients based on elixhauser comorbidities
+    van Walraven C, Austin PC, Jennings A, Quan H, Forster AJ. 
+    A modification of the Elixhauser comorbidity measures into a point system for hospital death using administrative data. 
+    Medical care. 2009 Jun 1:626-33.
+    """
     output = icdtoelixcomo(df,col_icd)
     output = output.loc[output['ElixComo'].notnull(),:]
     output = output.loc[:,[col_id,'ElixComo','ElixComoScore']]
@@ -81,9 +91,11 @@ def elixcomoscore(df,col_icd,col_id):
     return output
     
     
-# load mapping file from icd9 to Chronic Condition Indicator (CCI)
-#https://www.hcup-us.ahrq.gov/toolssoftware/chronic/chronic.jsp
 def load_cci9():
+    """
+    load mapping file from icd9 to Chronic Condition Indicator (CCI)
+    https://www.hcup-us.ahrq.gov/toolssoftware/chronic/chronic.jsp
+    """
     cci9 = pd.read_csv(pkg_resources.resource_filename(__name__,'cci2015.csv'),skiprows=1)
     cci9.columns = [i.strip('\'') for i in cci9.columns]
     
@@ -119,17 +131,19 @@ def load_cci9():
     
     return cci9
 
-#convert icd9 to CCI
 def icd9tocci(df,col_icd='icd9'):
+    """convert icd9 to CCI"""
     cci9 = load_cci9()
     return df.merge(cci9,how='left',left_on=col_icd,right_on='ICD-9-CM CODE')
     
     
     
 
-# load mapping file from icd10 to Chronic Condition Indicator (CCI)
-#https://www.hcup-us.ahrq.gov/toolssoftware/chronic_icd10/chronic_icd10.jsp
 def load_cci10():
+    """
+    load mapping file from icd10 to Chronic Condition Indicator (CCI)
+    https://www.hcup-us.ahrq.gov/toolssoftware/chronic_icd10/chronic_icd10.jsp
+    """
     
     cci10 = pd.read_csv(pkg_resources.resource_filename(__name__,'cci_icd10cm_2019_1.csv'))
     
@@ -167,14 +181,16 @@ def load_cci10():
     
     return cci10
 
-#convert icd10 to CCI
 def icd10tocci(df,col_icd='icd10'):
+    """convert icd10 to CCI"""
     cci10 = load_cci10()
     return df.merge(cci10,how='left',left_on=col_icd,right_on='ICD-10-CM CODE')
 
-# load mapping file from icd9 to Clinical Classification Software (CCS)
-#https://www.hcup-us.ahrq.gov/toolssoftware/ccs/ccs.jsp
 def load_ccs9():
+    """
+    load mapping file from icd9 to Clinical Classification Software (CCS)
+    https://www.hcup-us.ahrq.gov/toolssoftware/ccs/ccs.jsp
+    """
     ccs9 = pd.read_csv(pkg_resources.resource_filename(__name__,'$dxref 2015.csv'))
     ccs9 = ccs9.reset_index()
     for col in ccs9.columns:
@@ -193,17 +209,19 @@ def load_ccs9():
     ccs9.columns = [i.replace('CCS DIAGNOSIS CATEGORIES LABELS','CCS CATEGORY DESCRIPTION') for i in ccs9.columns]
     return ccs9
 
-#convert icd9 to CCS
 def icd9toccs(df,col_icd='icd9'):
+    """convert icd9 to CCS"""
     ccs9 = load_ccs9()
     output = df.merge(ccs9,how='left',left_on=col_icd,right_on='ICD-9-CM CODE')
     if col_icd!='ICD-9-CM CODE':
         output.drop('ICD-9-CM CODE',axis=1,inplace=True)
     return output
 
-# load mapping file from icd10 to Clinical Classification Software (CCS)
-#https://www.hcup-us.ahrq.gov/toolssoftware/ccs10/ccs10.jsp
 def load_ccs10():
+    """
+    load mapping file from icd10 to Clinical Classification Software (CCS)
+    https://www.hcup-us.ahrq.gov/toolssoftware/ccs10/ccs10.jsp
+    """
     ccs10 = pd.read_csv(pkg_resources.resource_filename(__name__,'ccs_dx_icd10cm_2019_1.csv'))
     ccs10.columns=[i.strip('\'') for i in ccs10.columns]
     for col in ccs10.columns:
@@ -214,16 +232,16 @@ def load_ccs10():
     return ccs10
     
 
-#convert icd10toccs    
 def icd10toccs(df,col_icd='icd10'):
+    """convert icd10 to ccs"""
     ccs10 = load_ccs10()
     output = df.merge(ccs10,how='left',left_on=col_icd,right_on='ICD-10-CM CODE')
     if col_icd!='ICD-10-CM CODE':
         output.drop('ICD-10-CM CODE',axis=1,inplace=True)
     return output
 
-#parse diagnosis dataset and include Clinical Classification Software, Chronic Glag, and Elixhauser Comorbidity
 def parsediag(dfin,col_icd,col_id,icd_version):
+    """parse diagnosis dataset and include Clinical Classification Software, Chronic Glag, and Elixhauser Comorbidity"""
     df = dfin.copy()
     
     if icd_version==9:
@@ -250,12 +268,12 @@ def parsediag(dfin,col_icd,col_id,icd_version):
     
     return df
 
-# onehotifying categorical columns
 def onehotify(df,col_id,col_val):
+    """onehotifying categorical columns"""
     return pd.concat([df.loc[:,[col_id]],pd.get_dummies(df[col_val])],axis=1).groupby(col_id).max()
 
-#convert NDC codes to RXCUI
 def ndc2rxcui(df_med,col_ndc='ndc'):
+    """convert NDC codes to RXCUI"""
     print('Converting NDC to RXCUI')
     output=[]
     ndclist=df_med[col_ndc].unique()
@@ -278,8 +296,8 @@ def ndc2rxcui(df_med,col_ndc='ndc'):
     output=pd.DataFrame(output).replace({r'^\s*$':None}, regex=True).dropna()
     return output
 
-#convert RXCUI to drug classes
 def rxcui2class(df_mapin,getname=True):
+    """convert RXCUI to drug classes"""
     print('Converting rxcui to drug class')
     rxcuilist=df_mapin['rxcui'].unique()
     lenrxcui=len(rxcuilist)
@@ -308,8 +326,8 @@ def rxcui2class(df_mapin,getname=True):
         time.sleep(1/20)
     return pd.DataFrame(output)
 
-#combine NDC2RXCUI and RXCUI2CLASS to go from NDC to CLASS
 def ndc2class(df_med,col_ndc='ndc',getname=True,indexcol='ROWID',timecol='TIME'):
+    """combine NDC2RXCUI and RXCUI2CLASS to go from NDC to CLASS"""
     map1=ndc2rxcui(df_med,col_ndc=col_ndc)
     map2=rxcui2class(map1,getname=getname)
 


### PR DESCRIPTION
This addresses issue #1 

This will make the output of the help() function easier to read because the # symbol will not appear at the beginning of each line. Also, it is easier to read the documentation while browsing the source.

A future step might be using a standard docstring format (like the Numpy documentation format)